### PR TITLE
Support ddtrace-py v3.12.4

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -752,6 +752,10 @@ lib.composeManyExtensions [
           ++ lib.optionals (! final.python ? modules) [ pkgs.ncurses ];
       });
 
+      ddtrace = prev.ddtrace.overridePythonAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ cmake ];
+      });
+
       dcli = prev.dcli.overridePythonAttrs (old: {
         propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ final.setuptools ];
       });

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -753,7 +753,7 @@ lib.composeManyExtensions [
       });
 
       ddtrace = prev.ddtrace.overridePythonAttrs (old: {
-        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ cmake ];
+        buildInputs = (old.buildInputs or []) ++ [ final.cmake ];
       });
 
       dcli = prev.dcli.overridePythonAttrs (old: {

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -753,7 +753,8 @@ lib.composeManyExtensions [
       });
 
       ddtrace = prev.ddtrace.overridePythonAttrs (old: {
-        buildInputs = (old.buildInputs or []) ++ [ final.cmake ];
+        # There are CMakeLists in the fetched wheel, but we don't need to do anything with them.
+        dontUseCmakeConfigure = true;
       });
 
       dcli = prev.dcli.overridePythonAttrs (old: {

--- a/vendor/pyproject.nix/lib/pep508.nix
+++ b/vendor/pyproject.nix/lib/pep508.nix
@@ -100,6 +100,7 @@ let
     ">=" = a: b: a >= b;
     "<" = a: b: a < b;
     ">" = a: b: a > b;
+    "~=" = a: b: a == b;  # Compatible release - delegate to pep440.comparators for version objects
     "===" = a: b: a == b;
   };
 
@@ -129,9 +130,10 @@ let
       a: b: if isAttrs a && isAttrs b then pep440.comparators.">=" a b else (a.str or a) >= (b.str or b);
     "<" =
       a: b: if isAttrs a && isAttrs b then pep440.comparators."<" a b else (a.str or a) < (b.str or b);
-
     ">" =
       a: b: if isAttrs a && isAttrs b then pep440.comparators.">" a b else (a.str or a) > (b.str or b);
+    "~=" =
+      a: b: if isAttrs a && isAttrs b then pep440.comparators."~=" a b else (a.str or a) == (b.str or b);
     "===" = a: b: a == b;
   };
 

--- a/vendor/pyproject.nix/lib/pypa.nix
+++ b/vendor/pyproject.nix/lib/pypa.nix
@@ -264,7 +264,13 @@ lib.fix (self: {
             (arch == "universal2" && (platform.darwinArch == "arm64" || platform.darwinArch == "x86_64"))
             || arch == platform.darwinArch
           )
-          && compareVersions platform.darwinSdkVersion "${major}.${minor}" >= 0
+          && (
+            # Original check
+            compareVersions platform.darwinSdkVersion "${major}.${minor}" >= 0
+            # Allow wheels built for macOS 12.0 to work on 11.3+
+            # This is generally safe as macOS maintains backward compatibility
+            || (platform.darwinSdkVersion == "11.3" && "${major}.${minor}" == "12.0")
+          )
         )
       )
     else if platformTag == "win32" then


### PR DESCRIPTION
This change makes two key changes needed to install ddtrace v3:

- Add pep508 support for `~=` release comparators
- Relax darwin SDK version checks to allow wheels packaged for darwin SDK 12 to be used with darwin SDK 11.3. This is the targetPlatform.darwinSdkVersion in nixpkgs for now, and it isn't trivial to override without having to build python from source. So instead we use a bit of a hack. This should generally be fine, as most python packages don't use cutting-edge MacOS features, and many newer versions of python packages are starting to only provide SDK v12 wheels. This works for us because we only use darwin versions of dependencies during development, and deploy on Linux. Caution should be used when using darwin packages built with this change in production.